### PR TITLE
el: Fix "yo is not defined" error

### DIFF
--- a/el/index.js
+++ b/el/index.js
@@ -34,7 +34,7 @@ var GeneratorPolymerTS;
             this.yo.prompt(prompts, function (answers) {
                 this.yo.includeImport = answers.includeImport;
                 done();
-            }.bind(yo));
+            }.bind(this.yo));
         };
         El.prototype.configuring = function () {
         };

--- a/el/index.ts
+++ b/el/index.ts
@@ -83,7 +83,7 @@ module GeneratorPolymerTS {
         this.yo.prompt(prompts, function (answers:any) {
           this.yo.includeImport = answers.includeImport;
           done();
-        }.bind(yo));
+        }.bind(this.yo));
 
     }
 


### PR DESCRIPTION
Fix for the following error:

```
$ yo polymerts:el my-element
events.js:154
      throw er; // Unhandled 'error' event
      ^

ReferenceError: yo is not defined
    at El.prompting (/home/jan/.node_modules/lib/node_modules/generator-polymerts/el/index.js:37:20)
    at /home/jan/.node_modules/lib/node_modules/generator-polymerts/node_modules/yeoman-generator/lib/base.js:429:16
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```
